### PR TITLE
Update ecb API link

### DIFF
--- a/rsu-tax-calculator-cdk/lib/rsu-tax-calculator-cdk-stack.ts
+++ b/rsu-tax-calculator-cdk/lib/rsu-tax-calculator-cdk-stack.ts
@@ -17,7 +17,7 @@ export class RsuTaxCalculatorCdkStack extends cdk.Stack {
     new StaticSite(this, 'StaticSite', {
       domainName: 'huhtanen.eu',
       siteSubDomain: 'tax-calculator',
-      ecbDomain: 'sdw-wsrest.ecb.europa.eu',
+      ecbDomain: 'data-api.ecb.europa.eu',
       ecbPath:'/service/data/EXR/D.USD.EUR.SP00.A',
       ecbParams:['startPeriod', 'format', 'detail'],
       sourcePath: this.node.tryGetContext('sourcePath')


### PR DESCRIPTION
Due to [deprecation](https://data.ecb.europa.eu/help/api/overview) 
```
Migrating SDW API queries to EDP API queries - end of redirections as of October 1st, 2025

The SDW web services API were repointed to the ECB Data Portal API as of the official ECB Data Portal go-live two years ago. User requests are currently automatically redirected from https://sdw-wsrest.ecb.europa.eu/ to https://data-api.ecb.europa.eu/. 

Please proactively change your reference from SDW API to ECB Data Portal API as the redirections that are provided will be running only until October 1st, 2025.
```