### PR TITLE
End of year export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.13.0-beta
+* Added option to input shares held in the account before the start of the uploaded history files.
+* Added option to download a file that lists shares held in both accounts at the end of a selected year.
+
 ## v0.12.0-beta
 * Added proper reporting of forced quick sale of ESPP shares.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rsu-tax-calculator",
-  "version": "0.12.0-beta",
+  "version": "0.13.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rsu-tax-calculator",
-      "version": "0.12.0-beta",
+      "version": "0.13.0-beta",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsu-tax-calculator",
-  "version": "0.12.0-beta",
+  "version": "0.13.0-beta",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Container } from '@mui/system';
 import { ThemeProvider, createTheme, Typography, Divider, CircularProgress, Box, Link } from '@mui/material';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
-import { calculateTaxes, TaxSaleOfSecurity } from './calculator';
+import { calculateTaxResults, CalculationResult } from './calculator';
 import { ECBConverter } from './ecbRates';
 import { CalculationSettings, InputPanel } from './InputPanel/InputPanel';
 import { ResultsPanel } from './ResultsPanel/ResultsPanel';
@@ -18,7 +18,7 @@ const CHANGELOG_URL = 'https://github.com/hanzki/rsu-tax-calculator/blob/master/
 
 function App() {
   const [ecbConverter, setECBConverter] = React.useState<ECBConverter>();
-  const [taxReport, setTaxReport] = React.useState<TaxSaleOfSecurity[]>();
+  const [calculationResult, setCalculationResult] = React.useState<CalculationResult>();
   const [calculating, setCalculating] = React.useState(false);
   const [error, setError] = React.useState<any>();
 
@@ -37,7 +37,7 @@ function App() {
           throw new Error('Missing ECB currency rates');
         }
         try {
-          setTaxReport(calculateTaxes(
+          setCalculationResult(calculateTaxResults(
             settings.individualHistory,
             settings.eacHistory,
             ecbConverter,
@@ -99,9 +99,12 @@ function App() {
 
           { error && <CalculationError/> }
 
-          { taxReport && <ResultsPanel taxReport={taxReport}/> }
+          { calculationResult && <ResultsPanel
+            taxReport={calculationResult.taxReport}
+            yearEndStatementsByYear={calculationResult.yearEndStatementsByYear}
+          /> }
 
-          { (calculating || taxReport) && <Divider variant='middle' sx={{m: 1}}/>}
+          { (calculating || calculationResult) && <Divider variant='middle' sx={{m: 1}}/>}
 
           <Footer/>
         </Container>

--- a/src/InstructionsPanel/InstructionsPanel.tsx
+++ b/src/InstructionsPanel/InstructionsPanel.tsx
@@ -68,9 +68,8 @@ export const InstructionsPanel: React.FC<InstructionsPanelProps> = () => {
             </Alert>
             <Alert severity="info">
                 <AlertTitle sx={{fontWeight: 'bold'}}>New Features</AlertTitle>
+                <strong>0.13.x</strong> - The calculator now supports inputting shares held in the account before the start of the uploaded history files. You can also download a file that lists shares held in both accounts at the end of a selected year.<br/>
                 <strong>0.12.x</strong> - The calculator now reports correctly forced sale of ESPP shares.<br/>
-                <strong>0.11.x</strong> - The calculator now supports new transaction types added in 2024.<br/>
-                <strong>0.10.x</strong> - The calculator is now discounting 10% from ESPP sale price to match the 10% discount to earned income tax for ESPP purchases.<br/>
             </Alert>
         </Stack>
         <Container maxWidth="sm">

--- a/src/ResultsPanel/ResultsPanel.tsx
+++ b/src/ResultsPanel/ResultsPanel.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from "@mui/material"
 import React from "react"
 import { last, sumBy, uniq } from "lodash";
 import * as Papa from 'papaparse';
-import { TaxSaleOfSecurity } from "../calculator";
+import { TaxSaleOfSecurity, YearEndStatementsByYear } from "../calculator";
 import { PeriodSelector } from "./PeriodSelector";
 import { SaleOfSecuritiesTable } from "./SaleOfSecuritiesTable";
 import { InsightCard } from "./InsightCard";
@@ -15,7 +15,8 @@ declare global {
 }
 
 export type ResultsPanelProps = {
-    taxReport: TaxSaleOfSecurity[]
+    taxReport: TaxSaleOfSecurity[],
+    yearEndStatementsByYear: YearEndStatementsByYear,
 }
 
 const Spacer = () => <Box sx={{m: 1}}/>;
@@ -58,7 +59,8 @@ const CSV_EXPORT_COLUMNS: (keyof ReturnType<typeof formatForExport>)[] = [
 ];
 
 export const ResultsPanel: React.FC<ResultsPanelProps> = ({
-    taxReport
+    taxReport,
+    yearEndStatementsByYear
 }) => {
     const periods = uniq(taxReport.map(t => t.saleDate.getFullYear().toString())).sort();
     if (periods.length < 1) {
@@ -98,6 +100,43 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
         document.body.removeChild(elem);
     }
 
+    const downloadYearEndStatement = () => {
+        const yearEndStatement = yearEndStatementsByYear[period];
+        if (!yearEndStatement) {
+            throw new Error(`No year-end statement available for ${period}`);
+        }
+
+        const formatLot = (lot: typeof yearEndStatement.individual[number]) => ({
+            ...lot,
+            purchaseDate: format(lot.purchaseDate, 'yyyy-MM-dd'),
+        });
+
+        const fileContent = JSON.stringify({
+            selectedYear: period,
+            generatedAt: format(new Date(), "yyyy-MM-dd'T'HH:mm:ssxxx"),
+            appVersion: __APP_VERSION__,
+            accounts: {
+                individual: yearEndStatement.individual.map(formatLot),
+                eac: yearEndStatement.eac.map(formatLot),
+            }
+        }, null, 2);
+        const filename = `rsu_year_end_statement_${period}_${format(new Date(), 'yyyyMMdd')}.json`;
+
+        const blob = new Blob([fileContent], { type: 'application/json' });
+
+        if (window.navigator.msSaveBlob) {
+            window.navigator.msSaveBlob(blob, filename);
+            return;
+        }
+
+        const elem = window.document.createElement('a');
+        elem.href = window.URL.createObjectURL(blob);
+        elem.download = filename;
+        document.body.appendChild(elem);
+        elem.click();
+        document.body.removeChild(elem);
+    }
+
     return <Box sx={{
         padding: '10px',
         display: 'flex',
@@ -121,6 +160,10 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
             <Spacer/>
             <InsightCard title="Capital losses" valueEUR={capitalLoss}/>
         </Box>
-        <SaleOfSecuritiesTable transactions={salesWithinPeriod} onDownload={downloadReport}/>
+        <SaleOfSecuritiesTable
+            transactions={salesWithinPeriod}
+            onDownload={downloadReport}
+            onDownloadYearEndStatement={downloadYearEndStatement}
+        />
     </Box>
 };

--- a/src/ResultsPanel/ResultsPanel.tsx
+++ b/src/ResultsPanel/ResultsPanel.tsx
@@ -6,7 +6,7 @@ import { TaxSaleOfSecurity, YearEndStatementsByYear } from "../calculator";
 import { PeriodSelector } from "./PeriodSelector";
 import { SaleOfSecuritiesTable } from "./SaleOfSecuritiesTable";
 import { InsightCard } from "./InsightCard";
-import { format } from "date-fns";
+import { endOfYear, format, max } from "date-fns";
 
 declare global {
     interface Navigator {
@@ -111,8 +111,15 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
             purchaseDate: format(lot.purchaseDate, 'yyyy-MM-dd'),
         });
 
+        const latestPeriod = periods[periods.length - 1];
+        const throughDate =
+            period === latestPeriod && salesWithinPeriod.length > 0
+                ? max(salesWithinPeriod.map(t => t.saleDate))
+                : endOfYear(new Date(parseInt(period, 10), 0, 1));
+        const reportThroughDate = format(throughDate, 'yyyy-MM-dd');
+
         const fileContent = JSON.stringify({
-            selectedYear: period,
+            reportThroughDate,
             generatedAt: format(new Date(), "yyyy-MM-dd'T'HH:mm:ssxxx"),
             appVersion: __APP_VERSION__,
             accounts: {
@@ -120,7 +127,7 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
                 eac: yearEndStatement.eac.map(formatLot),
             }
         }, null, 2);
-        const filename = `rsu_year_end_statement_${period}_${format(new Date(), 'yyyyMMdd')}.json`;
+        const filename = `rsu_year_end_statement_${reportThroughDate}_${format(new Date(), 'yyyyMMdd')}.json`;
 
         const blob = new Blob([fileContent], { type: 'application/json' });
 

--- a/src/ResultsPanel/SaleOfSecuritiesTable.tsx
+++ b/src/ResultsPanel/SaleOfSecuritiesTable.tsx
@@ -14,11 +14,13 @@ import { TaxSaleOfSecurity } from "../calculator";
 export type SaleOfSecuritiesTableProps = {
     transactions: TaxSaleOfSecurity[],
     onDownload: () => unknown,
+    onDownloadYearEndStatement: () => unknown,
 }
 
 export const SaleOfSecuritiesTable: React.FC<SaleOfSecuritiesTableProps> = ({
     transactions,
-    onDownload
+    onDownload,
+    onDownloadYearEndStatement
 }) => {
 
 const accountName = (row: TaxSaleOfSecurity) => row.isESPP ? 'EAC': 'Individual';
@@ -29,7 +31,10 @@ return <Box>
         mb: 1
     }}>
         <Typography variant="h5" textAlign="left" component='span'>Sales within the period</Typography>
-        <Button variant="text" size="small" startIcon={<DownloadRoundedIcon/>} onClick={onDownload}>Download</Button>
+        <Box>
+            <Button variant="text" size="small" startIcon={<DownloadRoundedIcon/>} onClick={onDownloadYearEndStatement}>Download Year-End Statement</Button>
+            <Button variant="text" size="small" startIcon={<DownloadRoundedIcon/>} onClick={onDownload}>Download Sales</Button>
+        </Box>
     </Box>
     <TableContainer component={Paper}>
         <Table sx={{ minWidth: 650 }} aria-label="simple table">

--- a/src/calculator/index.test.ts
+++ b/src/calculator/index.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, beforeEach, it } from 'vitest'
 import { EACHistoryData, IndividualHistoryData } from '../test/data';
 import * as Calculator from './index';
 import { EAC, Individual } from './types';
+import { ECBConverter } from '../ecbRates';
 
 describe('calculator', () => {
     describe('filterStockTransactions', () => {
@@ -363,6 +364,133 @@ describe('calculator', () => {
                     purchasePriceUSD: lots[0].purchasePriceUSD,
                     quantity: stockTransactions[0].quantity
                 })
+            });
+        });
+    });
+
+    describe('calculateTaxResults', () => {
+        it('builds year-end USD lot snapshots for both accounts by selected sale years', () => {
+            const individualHistory: Individual.Transaction[] = [
+                IndividualHistoryData.spaTransaction({ date: new Date(2020, 0, 15), quantity: 100, symbol: 'U' }),
+                IndividualHistoryData.sellTransaction({ date: new Date(2021, 5, 10), quantity: 40, symbol: 'U', priceUSD: 55 }),
+                IndividualHistoryData.sellTransaction({ date: new Date(2022, 6, 10), quantity: 20, symbol: 'U', priceUSD: 60 }),
+            ];
+
+            const eacHistory: EAC.Transaction[] = [
+                EACHistoryData.lapseTransaction({
+                    date: new Date(2020, 0, 15),
+                    symbol: 'U',
+                    lapseDetails: {
+                        sharesDeposited: 100,
+                        sharesSold: 0,
+                        fmvUSD: 10
+                    }
+                }),
+                {
+                    action: EAC.Action.Deposit,
+                    date: new Date(2020, 0, 2),
+                    symbol: 'U',
+                    description: 'ESPP Deposit',
+                    quantity: 50,
+                    depositDetails: {
+                        subscriptionDate: new Date(2019, 10, 1),
+                        subscriptionFMVUSD: 10,
+                        purchaseDate: new Date(2020, 0, 2),
+                        purchasePriceUSD: 9,
+                        purchaseFMVUSD: 10,
+                    }
+                },
+                {
+                    action: EAC.Action.Sale,
+                    date: new Date(2021, 8, 1),
+                    symbol: 'U',
+                    description: 'ESPP Sale 2021',
+                    quantity: 10,
+                    feesUSD: 0,
+                    amountUSD: 120,
+                    rows: [
+                        {
+                            type: 'ESPP',
+                            shares: 10,
+                            salePriceUSD: 12,
+                            subscriptionDate: new Date(2019, 10, 1),
+                            subscriptionFMVUSD: 10,
+                            purchaseDate: new Date(2020, 0, 2),
+                            purchasePriceUSD: 9,
+                            purchaseFMVUSD: 10,
+                            grossProceedsUSD: 120,
+                        }
+                    ]
+                },
+                {
+                    action: EAC.Action.Sale,
+                    date: new Date(2022, 8, 1),
+                    symbol: 'U',
+                    description: 'ESPP Sale 2022',
+                    quantity: 15,
+                    feesUSD: 0,
+                    amountUSD: 180,
+                    rows: [
+                        {
+                            type: 'ESPP',
+                            shares: 15,
+                            salePriceUSD: 12,
+                            subscriptionDate: new Date(2019, 10, 1),
+                            subscriptionFMVUSD: 10,
+                            purchaseDate: new Date(2020, 0, 2),
+                            purchasePriceUSD: 9,
+                            purchaseFMVUSD: 10,
+                            grossProceedsUSD: 180,
+                        }
+                    ]
+                }
+            ] as EAC.Transaction[];
+
+            const ecbConverterMock = {
+                usdToEUR: (usdValue: number) => usdValue,
+                usdToEURRate: () => 1,
+            } as ECBConverter;
+
+            const result = Calculator.calculateTaxResults(individualHistory, eacHistory, ecbConverterMock);
+
+            expect(Object.keys(result.yearEndStatementsByYear)).toEqual(['2021', '2022']);
+
+            expect(result.yearEndStatementsByYear['2021']).toEqual({
+                individual: [
+                    {
+                        symbol: 'U',
+                        quantity: 60,
+                        purchaseDate: new Date(2020, 0, 15),
+                        purchasePriceUSD: 10,
+                    }
+                ],
+                eac: [
+                    {
+                        symbol: 'U',
+                        quantity: 40,
+                        purchaseDate: new Date(2020, 0, 2),
+                        purchasePriceUSD: 9,
+                    }
+                ]
+            });
+
+            expect(result.yearEndStatementsByYear['2022']).toEqual({
+                individual: [
+                    {
+                        symbol: 'U',
+                        quantity: 40,
+                        purchaseDate: new Date(2020, 0, 15),
+                        purchasePriceUSD: 10,
+                    }
+                ],
+                eac: [
+                    {
+                        symbol: 'U',
+                        quantity: 25,
+                        purchaseDate: new Date(2020, 0, 2),
+                        purchasePriceUSD: 9,
+                    }
+                ]
             });
         });
     });

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -44,7 +44,7 @@ const isOptionSaleTransaction = (t: EAC.Transaction): t is OptionSaleTransaction
 type ESPPSaleTraction = EAC.SaleTransaction | EAC.ForcedQuickSellTransaction;
 
 const isSaleTransaction = (t: EAC.Transaction): t is EAC.SaleTransaction => t.action === EAC.Action.Sale;
-const isForcedQuickSellTransaction = (t: EAC.Transaction): t is EAC.SaleTransaction => t.action === EAC.Action.ForcedQuickSell;
+const isForcedQuickSellTransaction = (t: EAC.Transaction): t is EAC.ForcedQuickSellTransaction => t.action === EAC.Action.ForcedQuickSell;
 const isESPPSaleTransaction = (t: EAC.Transaction): t is ESPPSaleTraction => isSaleTransaction(t) || isForcedQuickSellTransaction(t);
 
 const isSellToCoverSellRow = (r: EAC.SellToCoverTransaction['rows'][number]): r is EAC.SellToCoverSellRow => r.action === EAC.SellToCoverAction.Sell;
@@ -162,6 +162,25 @@ export interface Lot {
     quantity: number,
     purchaseDate: Date,
     purchasePriceUSD: number,
+}
+
+export interface YearEndLot {
+    symbol: string,
+    quantity: number,
+    purchaseDate: Date,
+    purchasePriceUSD: number,
+}
+
+export interface YearEndStatementAccounts {
+    individual: YearEndLot[],
+    eac: YearEndLot[],
+}
+
+export type YearEndStatementsByYear = Record<string, YearEndStatementAccounts>;
+
+export interface CalculationResult {
+    taxReport: TaxSaleOfSecurity[],
+    yearEndStatementsByYear: YearEndStatementsByYear,
 }
 
 /**
@@ -325,12 +344,110 @@ function getCorrectESPPCostBasis(purchaseFMV: number, purchasePrice: number): nu
     return Math.max(purchasePrice, purchaseFMV - maxTaxFreeDiscount);
 }
 
+function remainingLotsAtCutoff(lots: Lot[], forfeitureEvents: ForfeitureEvent[], cutoff: Date): YearEndLot[] {
+    const cutoffEvents = forfeitureEvents
+        .filter(event => !isBefore(cutoff, event.date))
+        .sort(sortChronologicalBy(event => event.date));
+    const chronologicalLots = [...lots].sort(sortChronologicalBy(lot => lot.purchaseDate));
+
+    const lotRemainder = chronologicalLots.map(lot => ({
+        lot,
+        remainingQuantity: lot.quantity
+    }));
+
+    let currentLotIndex = 0;
+    for (const event of cutoffEvents) {
+        let remainingEventQuantity = event.quantity;
+
+        while (remainingEventQuantity > 0) {
+            const currentLot = lotRemainder[currentLotIndex];
+            if (!currentLot) {
+                const forfeitureDate = event.date.toLocaleDateString();
+                throw new Error(`Couldn't match stock forfeiture event on ${forfeitureDate} to a lot`);
+            }
+            if (isBefore(event.date, currentLot.lot.purchaseDate)) {
+                const forfeitureDate = event.date.toLocaleDateString();
+                throw new Error(`Couldn't match stock forfeiture event on ${forfeitureDate} to a lot`);
+            }
+            if (currentLot.remainingQuantity < 1) {
+                currentLotIndex += 1;
+                continue;
+            }
+
+            const matchedQuantity = Math.min(currentLot.remainingQuantity, remainingEventQuantity);
+            currentLot.remainingQuantity -= matchedQuantity;
+            remainingEventQuantity -= matchedQuantity;
+
+            if (currentLot.remainingQuantity < 1) {
+                currentLotIndex += 1;
+            }
+        }
+    }
+
+    return lotRemainder
+        .filter(item => item.remainingQuantity > 0 && !isBefore(cutoff, item.lot.purchaseDate))
+        .map(item => ({
+            symbol: item.lot.symbol,
+            quantity: item.remainingQuantity,
+            purchaseDate: item.lot.purchaseDate,
+            purchasePriceUSD: item.lot.purchasePriceUSD,
+        }));
+}
+
+function buildEACDepositLots(eacHistory: EAC.Transaction[]): Lot[] {
+    const depositTransactions = eacHistory.filter((transaction): transaction is EAC.DepositTransaction => transaction.action === EAC.Action.Deposit);
+    return depositTransactions.map(transaction => ({
+        symbol: transaction.symbol,
+        quantity: transaction.quantity,
+        purchaseDate: transaction.depositDetails.purchaseDate,
+        purchasePriceUSD: getCorrectESPPCostBasis(transaction.depositDetails.purchaseFMVUSD, transaction.depositDetails.purchasePriceUSD),
+    }));
+}
+
+function buildEACForfeitureEvents(eacHistory: EAC.Transaction[]): ForfeitureEvent[] {
+    const esppSales = eacHistory.filter(isESPPSaleTransaction);
+    return esppSales.flatMap(transaction =>
+        transaction.rows.map(row => ({
+            date: transaction.date,
+            quantity: row.shares
+        }))
+    );
+}
+
+function buildYearEndStatementsByYear(
+    periods: string[],
+    individualLots: Lot[],
+    individualForfeitureEvents: ForfeitureEvent[],
+    eacLots: Lot[],
+    eacForfeitureEvents: ForfeitureEvent[]
+): YearEndStatementsByYear {
+    return periods.reduce<YearEndStatementsByYear>((result, period) => {
+        const year = Number(period);
+        const cutoff = new Date(year, 11, 31);
+
+        result[period] = {
+            individual: remainingLotsAtCutoff(individualLots, individualForfeitureEvents, cutoff),
+            eac: remainingLotsAtCutoff(eacLots, eacForfeitureEvents, cutoff),
+        };
+        return result;
+    }, {});
+}
+
 export function calculateTaxes(
     individualHistory: Individual.Transaction[],
     eacHistory: EAC.Transaction[],
     ecbConverter: ECBConverter,
     earlierLots?: { shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[]
     ): TaxSaleOfSecurity[] {
+        return calculateTaxResults(individualHistory, eacHistory, ecbConverter, earlierLots).taxReport;
+    }
+
+export function calculateTaxResults(
+    individualHistory: Individual.Transaction[],
+    eacHistory: EAC.Transaction[],
+    ecbConverter: ECBConverter,
+    earlierLots?: { shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[]
+    ): CalculationResult {
         // Filter out non-stock transactions
         const stockTransactions = filterStockTransactions(individualHistory);
 
@@ -387,6 +504,25 @@ export function calculateTaxes(
         const esppReport = createESPPTaxReport(esppTransactionsWithCostBasis, ecbConverter);
 
         const combinedReport = [...taxReport, ...esppReport].sort(sortChronologicalBy(row => row.saleDate));
+        const periods = _.uniq(combinedReport.map(row => row.saleDate.getFullYear().toString())).sort();
 
-        return combinedReport;
+        const individualForfeitureEvents = transactionsWithoutOptionSales
+            .filter(transaction => isSellTransaction(transaction) || (isSecurityTransferTransaction(transaction) && transaction.quantity < 0))
+            .map(transaction => ({
+                date: transaction.date,
+                quantity: Math.abs(transaction.quantity),
+            }));
+        const eacLots = buildEACDepositLots(eacHistory);
+        const eacForfeitureEvents = buildEACForfeitureEvents(eacHistory);
+
+        return {
+            taxReport: combinedReport,
+            yearEndStatementsByYear: buildYearEndStatementsByYear(
+                periods,
+                lots,
+                individualForfeitureEvents,
+                eacLots,
+                eacForfeitureEvents
+            ),
+        };
     }


### PR DESCRIPTION
This export file can be used later to upload earlier transactions on subsequent calculation rounds. I still need to add an option for this and make the calculation logic to ignore transactions which are older than the input file.