### PR TITLE
Year-end statement import and export alignment (v0.14.0-beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.14.0-beta
+* Added optional upload of a year-end statement JSON (from this app’s “Download Year-End Statement”) when the account already held shares before the Schwab export window. Transactions on or before `reportThroughDate` are omitted from the uploaded Individual and EAC histories; opening lots from the file are applied for both accounts.
+
 ## v0.13.0-beta
 * Added option to input shares held in the account before the start of the uploaded history files.
 * Added option to download a file that lists shares held in both accounts at the end of a selected year.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rsu-tax-calculator",
-  "version": "0.13.0-beta",
+  "version": "0.14.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rsu-tax-calculator",
-      "version": "0.13.0-beta",
+      "version": "0.14.0-beta",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsu-tax-calculator",
-  "version": "0.13.0-beta",
+  "version": "0.14.0-beta",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.10.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,6 +103,7 @@ function App() {
           { calculationResult && <ResultsPanel
             taxReport={calculationResult.taxReport}
             yearEndStatementsByYear={calculationResult.yearEndStatementsByYear}
+            maxHistoryTransactionDateByYear={calculationResult.maxHistoryTransactionDateByYear}
           /> }
 
           { (calculating || calculationResult) && <Divider variant='middle' sx={{m: 1}}/>}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,8 @@ function App() {
             settings.individualHistory,
             settings.eacHistory,
             ecbConverter,
-            settings.earlierLots
+            settings.earlierLots,
+            settings.earlierEacLots
           ));
         } catch (error: any) {
           setError(error);

--- a/src/InputPanel/AdditionalInput.tsx
+++ b/src/InputPanel/AdditionalInput.tsx
@@ -2,17 +2,27 @@ import React from "react";
 import { Box, Typography, FormControlLabel, Radio, RadioGroup, FormControl, TextField, Button } from "@mui/material";
 import { EAC, Individual } from "../calculator/types";
 import { analyzeInputData } from "../calculator/inputAnalyzer";
+import { FileUpload } from "../FileUpload/FileUpload";
+import { parseYearEndStatementExport, ParsedYearEndStatement } from "../parser/yearEndStatementParser";
+
+export type EarlierInputMode = 'none' | 'manual' | 'yearEnd';
 
 export type AdditionalInformationProps = {
     individualHistory?: Individual.Transaction[],
     eacHistory?: EAC.Transaction[]
     onLotsChange?: (lots: { shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[]) => void
+    onYearEndStatementChange?: (statement: ParsedYearEndStatement | undefined) => void
+    onEarlierInputModeChange?: (mode: EarlierInputMode) => void
+    yearEndStatementLoaded?: boolean
 }
 
 export const AdditionalInformation: React.FC<AdditionalInformationProps> = ({
     individualHistory,
     eacHistory,
-    onLotsChange
+    onLotsChange,
+    onYearEndStatementChange,
+    onEarlierInputModeChange,
+    yearEndStatementLoaded = false,
 }) => {
     let individualInfo = "Not loaded";
     let eacInfo = "Not loaded";
@@ -35,16 +45,31 @@ export const AdditionalInformation: React.FC<AdditionalInformationProps> = ({
         if (!earliestDate || metadata.firstTransactionDate < earliestDate) earliestDate = metadata.firstTransactionDate;
     }
 
-    const [selection, setSelection] = React.useState<'containsAll' | 'hasEarlier' | ''>('');
+    const [selection, setSelection] = React.useState<'containsAll' | 'hasEarlierManual' | 'hasEarlierYearEnd' | ''>('');
+    const [yearEndStatementError, setYearEndStatementError] = React.useState<unknown>();
 
     type Lot = { id: string; shares: string; acquisitionDate: string; totalCost: string };
     const [lots, setLots] = React.useState<Lot[]>([]);
 
     React.useEffect(() => {
-        if (selection === 'hasEarlier' && lots.length === 0) {
+        if (selection === 'hasEarlierManual' && lots.length === 0) {
             setLots([{ id: String(Date.now()), shares: '', acquisitionDate: '', totalCost: '' }]);
         }
     }, [selection]);
+
+    React.useEffect(() => {
+        if (!onEarlierInputModeChange) return;
+        if (selection === 'containsAll' || selection === '') onEarlierInputModeChange('none');
+        else if (selection === 'hasEarlierManual') onEarlierInputModeChange('manual');
+        else if (selection === 'hasEarlierYearEnd') onEarlierInputModeChange('yearEnd');
+    }, [selection, onEarlierInputModeChange]);
+
+    React.useEffect(() => {
+        if (selection !== 'hasEarlierYearEnd') {
+            onYearEndStatementChange?.(undefined);
+            setYearEndStatementError(undefined);
+        }
+    }, [selection, onYearEndStatementChange]);
 
     const addLot = () => setLots(s => [...s, { id: String(Date.now()) + Math.random().toString(36).slice(2,6), shares: '', acquisitionDate: '', totalCost: '' }]);
     const removeLot = (id: string) => setLots(s => s.filter(l => l.id !== id));
@@ -52,7 +77,7 @@ export const AdditionalInformation: React.FC<AdditionalInformationProps> = ({
 
     React.useEffect(() => {
         if (!onLotsChange) return;
-        if (selection !== 'hasEarlier') {
+        if (selection !== 'hasEarlierManual') {
             onLotsChange([]);
             return;
         }
@@ -76,7 +101,7 @@ export const AdditionalInformation: React.FC<AdditionalInformationProps> = ({
                     <FormControl component="fieldset">
                         <RadioGroup
                             value={selection}
-                            onChange={(e) => setSelection(e.target.value as 'containsAll' | 'hasEarlier' | '')}
+                            onChange={(e) => setSelection(e.target.value as 'containsAll' | 'hasEarlierManual' | 'hasEarlierYearEnd' | '')}
                         >
                             <FormControlLabel
                                 value="containsAll"
@@ -84,14 +109,57 @@ export const AdditionalInformation: React.FC<AdditionalInformationProps> = ({
                                 label={`My account didn't hold shares acquired before ${earliestDate.toLocaleDateString()}`}
                             />
                             <FormControlLabel
-                                value="hasEarlier"
+                                value="hasEarlierManual"
                                 control={<Radio />}
-                                label={`My account had shares acquired before ${earliestDate.toLocaleDateString()}`}
+                                label={`My account had shares acquired before ${earliestDate.toLocaleDateString()} (enter lots below)`}
+                            />
+                            <FormControlLabel
+                                value="hasEarlierYearEnd"
+                                control={<Radio />}
+                                label="I have a year-end statement JSON from this calculator (upload below)"
                             />
                         </RadioGroup>
                     </FormControl>
 
-                    {selection === 'hasEarlier' ? (
+                    {selection === 'hasEarlierYearEnd' ? (
+                        <Box sx={{ marginTop: '12px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
+                            <Typography variant="body2" sx={{ maxWidth: 420 }}>
+                                Upload the file from <strong>Download Year-End Statement</strong> for the last year you already processed.
+                                Transactions on or before the file&apos;s <strong>reportThroughDate</strong> are skipped; opening lots from the file are used instead.
+                            </Typography>
+                            <FileUpload
+                                accept="application/json"
+                                inputId="year-end-statement-upload"
+                                label="Year-end statement JSON"
+                                success={yearEndStatementLoaded}
+                                error={!!yearEndStatementError}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    if (event.target.files === null || event.target.files.length === 0) return;
+                                    const reader = new FileReader();
+                                    reader.onload = (e) => {
+                                        if (typeof e.target?.result !== 'string') return;
+                                        try {
+                                            const parsed = parseYearEndStatementExport(e.target.result);
+                                            setYearEndStatementError(undefined);
+                                            onYearEndStatementChange?.(parsed);
+                                        } catch (err: unknown) {
+                                            console.error('Failed to parse year-end statement.', err);
+                                            setYearEndStatementError(err);
+                                            onYearEndStatementChange?.(undefined);
+                                        }
+                                    };
+                                    reader.readAsText(event.target.files[0]);
+                                }}
+                            />
+                            {yearEndStatementError ? (
+                                <Typography variant="body2" color="error" sx={{ maxWidth: 420 }}>
+                                    {(yearEndStatementError as Error)?.message ?? String(yearEndStatementError)}
+                                </Typography>
+                            ) : null}
+                        </Box>
+                    ) : null}
+
+                    {selection === 'hasEarlierManual' ? (
                         <Box sx={{ marginTop: '8px', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                             <Typography variant="body2" sx={{ marginBottom: '8px' }}>
                                 Please list all shares your account had on {earliestDate.toLocaleDateString()} grouped by acquisition lot

--- a/src/InputPanel/InputPanel.tsx
+++ b/src/InputPanel/InputPanel.tsx
@@ -1,18 +1,20 @@
 import { Box, Typography } from "@mui/material"
 import React from "react"
 import { EAC, Individual } from "../calculator/types";
+import { Lot, filterHistoriesAfterYearEndReport } from "../calculator";
+import { ParsedYearEndStatement } from "../parser/yearEndStatementParser";
+import { EarlierInputMode, AdditionalInformation } from "./AdditionalInput";
 import { FileUpload, FileUploadProps } from "../FileUpload/FileUpload";
 import { parseEACHistory } from "../parser/schwabJSONEACHistoryParser";
 import { parseIndividualHistory } from "../parser/schwabJSONIndividualHistoryParser";
 import { CalculateButton } from "./CalculateButton";
 import { ErrorAlert } from "./ErrorAlert";
 import { WarningAlert } from "./WarningAlert";
-import { AdditionalInformation } from "./AdditionalInput";
-
 export type CalculationSettings = {
     individualHistory: Individual.Transaction[],
     eacHistory: EAC.Transaction[]
     earlierLots?: { shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[]
+    earlierEacLots?: Lot[]
 }
 
 export type InputPanelProps = {
@@ -29,8 +31,14 @@ export const InputPanel: React.FC<InputPanelProps> = ({
     const [calculating, setCalculating] = React.useState(false);
     const [calculationDone, setCalculationDone] = React.useState(false);
     const [earlierLots, setEarlierLots] = React.useState<{ shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[]>();
+    const [parsedYearEnd, setParsedYearEnd] = React.useState<ParsedYearEndStatement | undefined>();
+    const [earlierInputMode, setEarlierInputMode] = React.useState<EarlierInputMode>('none');
 
-    const readyToCalculate = individualHistory && eacHistory;
+    const readyToCalculate = Boolean(
+        individualHistory &&
+        eacHistory &&
+        (earlierInputMode !== 'yearEnd' || parsedYearEnd)
+    );
     const hasErrors = !!individualHistoryError || !!eacHistoryError;
 
     const warnings = [];
@@ -56,10 +64,28 @@ export const InputPanel: React.FC<InputPanelProps> = ({
         setCalculating(true);
 
         try {
+            let ind = individualHistory;
+            let eac = eacHistory;
+            let lotsForCalc = earlierLots;
+            let earlierEacLots: Lot[] | undefined;
+
+            if (earlierInputMode === 'yearEnd' && parsedYearEnd) {
+                const filtered = filterHistoriesAfterYearEndReport(ind, eac, parsedYearEnd.reportThroughDate);
+                ind = filtered.individualHistory;
+                eac = filtered.eacHistory;
+                lotsForCalc = parsedYearEnd.individualLots.map(lot => ({
+                    shares: lot.quantity,
+                    acquisitionDate: lot.purchaseDate,
+                    totalAcquisitionCost: lot.quantity * lot.purchasePriceUSD,
+                }));
+                earlierEacLots = parsedYearEnd.eacLots;
+            }
+
             await onCalculate({
-                individualHistory,
-                eacHistory,
-                earlierLots
+                individualHistory: ind,
+                eacHistory: eac,
+                earlierLots: lotsForCalc,
+                earlierEacLots,
             });
             setCalculationDone(true);
         } catch (err: any) {
@@ -149,6 +175,9 @@ export const InputPanel: React.FC<InputPanelProps> = ({
             individualHistory={individualHistory}
             eacHistory={eacHistory}
             onLotsChange={setEarlierLots}
+            onYearEndStatementChange={setParsedYearEnd}
+            onEarlierInputModeChange={setEarlierInputMode}
+            yearEndStatementLoaded={!!parsedYearEnd}
         /> : null}
         <CalculateButton
             onClick={doCalculate}

--- a/src/InstructionsPanel/InstructionsPanel.tsx
+++ b/src/InstructionsPanel/InstructionsPanel.tsx
@@ -68,6 +68,7 @@ export const InstructionsPanel: React.FC<InstructionsPanelProps> = () => {
             </Alert>
             <Alert severity="info">
                 <AlertTitle sx={{fontWeight: 'bold'}}>New Features</AlertTitle>
+                <strong>0.14.x</strong> - You can upload a prior year-end statement JSON (third option under earlier shares). Schwab history is trimmed at <strong>reportThroughDate</strong> and opening lots from the file are used for both accounts.<br/>
                 <strong>0.13.x</strong> - The calculator now supports inputting shares held in the account before the start of the uploaded history files. You can also download a file that lists shares held in both accounts at the end of a selected year.<br/>
                 <strong>0.12.x</strong> - The calculator now reports correctly forced sale of ESPP shares.<br/>
             </Alert>

--- a/src/ResultsPanel/ResultsPanel.tsx
+++ b/src/ResultsPanel/ResultsPanel.tsx
@@ -6,7 +6,7 @@ import { TaxSaleOfSecurity, YearEndStatementsByYear } from "../calculator";
 import { PeriodSelector } from "./PeriodSelector";
 import { SaleOfSecuritiesTable } from "./SaleOfSecuritiesTable";
 import { InsightCard } from "./InsightCard";
-import { endOfYear, format, max } from "date-fns";
+import { endOfYear, format } from "date-fns";
 
 declare global {
     interface Navigator {
@@ -17,6 +17,7 @@ declare global {
 export type ResultsPanelProps = {
     taxReport: TaxSaleOfSecurity[],
     yearEndStatementsByYear: YearEndStatementsByYear,
+    maxHistoryTransactionDateByYear: Record<string, Date>,
 }
 
 const Spacer = () => <Box sx={{m: 1}}/>;
@@ -60,7 +61,8 @@ const CSV_EXPORT_COLUMNS: (keyof ReturnType<typeof formatForExport>)[] = [
 
 export const ResultsPanel: React.FC<ResultsPanelProps> = ({
     taxReport,
-    yearEndStatementsByYear
+    yearEndStatementsByYear,
+    maxHistoryTransactionDateByYear,
 }) => {
     const periods = uniq(taxReport.map(t => t.saleDate.getFullYear().toString())).sort();
     if (periods.length < 1) {
@@ -112,9 +114,10 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({
         });
 
         const latestPeriod = periods[periods.length - 1];
+        const latestEventInYear = maxHistoryTransactionDateByYear[period];
         const throughDate =
-            period === latestPeriod && salesWithinPeriod.length > 0
-                ? max(salesWithinPeriod.map(t => t.saleDate))
+            period === latestPeriod && latestEventInYear !== undefined
+                ? latestEventInYear
                 : endOfYear(new Date(parseInt(period, 10), 0, 1));
         const reportThroughDate = format(throughDate, 'yyyy-MM-dd');
 

--- a/src/calculator/index.test.ts
+++ b/src/calculator/index.test.ts
@@ -476,6 +476,10 @@ describe('calculator', () => {
 
             const result = Calculator.calculateTaxResults(individualHistory, eacHistory, ecbConverterMock);
 
+            expect(result.maxHistoryTransactionDateByYear['2020']).toEqual(new Date(2020, 0, 15));
+            expect(result.maxHistoryTransactionDateByYear['2021']).toEqual(new Date(2021, 8, 1));
+            expect(result.maxHistoryTransactionDateByYear['2022']).toEqual(new Date(2022, 8, 1));
+
             expect(Object.keys(result.yearEndStatementsByYear)).toEqual(['2021', '2022']);
 
             expect(result.yearEndStatementsByYear['2021']).toEqual({

--- a/src/calculator/index.test.ts
+++ b/src/calculator/index.test.ts
@@ -112,7 +112,6 @@ describe('calculator', () => {
                         ],
                         details: {
                             exerciseCostUSD: 1250,
-                            grossProceedsUSD: 4750,
                             netProceedsUSD: 3499,
                         }
                     })
@@ -441,7 +440,6 @@ describe('calculator', () => {
                             purchaseDate: new Date(2020, 0, 2),
                             purchasePriceUSD: 9,
                             purchaseFMVUSD: 10,
-                            grossProceedsUSD: 120,
                         }
                     ]
                 },
@@ -463,7 +461,6 @@ describe('calculator', () => {
                             purchaseDate: new Date(2020, 0, 2),
                             purchasePriceUSD: 9,
                             purchaseFMVUSD: 10,
-                            grossProceedsUSD: 180,
                         }
                     ]
                 }

--- a/src/calculator/index.test.ts
+++ b/src/calculator/index.test.ts
@@ -24,6 +24,29 @@ describe('calculator', () => {
         });
     });
 
+    describe('filterHistoriesAfterYearEndReport', () => {
+        it('removes transactions on or before reportThroughDate', () => {
+            const cutoff = new Date(2021, 5, 15);
+            const individualHistory: Individual.Transaction[] = [
+                IndividualHistoryData.sellTransaction({ date: new Date(2021, 5, 10), quantity: 1 }),
+                IndividualHistoryData.sellTransaction({ date: new Date(2021, 5, 15), quantity: 2 }),
+                IndividualHistoryData.sellTransaction({ date: new Date(2021, 5, 16), quantity: 3 }),
+            ];
+            const eacHistory: EAC.Transaction[] = [
+                EACHistoryData.lapseTransaction({ date: new Date(2021, 5, 14) }),
+                EACHistoryData.lapseTransaction({ date: new Date(2021, 6, 1) }),
+            ];
+            const { individualHistory: ind, eacHistory: eac } = Calculator.filterHistoriesAfterYearEndReport(
+                individualHistory,
+                eacHistory,
+                cutoff
+            );
+            expect(ind.map(t => t.date.getTime())).toEqual([individualHistory[2].date.getTime()]);
+            expect(eac).toHaveLength(1);
+            expect(eac[0].date.getTime()).toEqual(eacHistory[1].date.getTime());
+        });
+    });
+
     describe('filterOutOptionSales', () => {
         let stockTransactions: Calculator.StockTransaction[];
         let eacHistory: EAC.Transaction[];

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -1,4 +1,4 @@
-import { isBefore, isEqual } from "date-fns";
+import { isBefore, isEqual, isAfter, startOfDay } from "date-fns";
 import _ from "lodash";
 import { ECBConverter } from "../ecbRates";
 import { isWithinAWeek, sortChronologicalBy, sortReverseChronologicalBy } from "../util";
@@ -58,6 +58,23 @@ const isSellToCoverHoldRow = (r: EAC.SellToCoverTransaction['rows'][number]): r 
  */
 export function filterStockTransactions(individualHistory: Individual.Transaction[]): StockTransaction[] {
     return individualHistory.filter(isStockTransaction);
+}
+
+/**
+ * Drops transactions on or before {@link reportThroughDate} (calendar day in local time).
+ * Used with a prior year-end export so overlapping history is not processed twice.
+ */
+export function filterHistoriesAfterYearEndReport(
+    individualHistory: Individual.Transaction[],
+    eacHistory: EAC.Transaction[],
+    reportThroughDate: Date
+): { individualHistory: Individual.Transaction[]; eacHistory: EAC.Transaction[] } {
+    const cutoff = startOfDay(reportThroughDate);
+    const keep = (d: Date) => isAfter(startOfDay(d), cutoff);
+    return {
+        individualHistory: individualHistory.filter(t => keep(t.date)),
+        eacHistory: eacHistory.filter(t => keep(t.date)),
+    };
 }
 
 
@@ -437,16 +454,18 @@ export function calculateTaxes(
     individualHistory: Individual.Transaction[],
     eacHistory: EAC.Transaction[],
     ecbConverter: ECBConverter,
-    earlierLots?: { shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[]
+    earlierLots?: { shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[],
+    earlierEacLots?: Lot[]
     ): TaxSaleOfSecurity[] {
-        return calculateTaxResults(individualHistory, eacHistory, ecbConverter, earlierLots).taxReport;
+        return calculateTaxResults(individualHistory, eacHistory, ecbConverter, earlierLots, earlierEacLots).taxReport;
     }
 
 export function calculateTaxResults(
     individualHistory: Individual.Transaction[],
     eacHistory: EAC.Transaction[],
     ecbConverter: ECBConverter,
-    earlierLots?: { shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[]
+    earlierLots?: { shares: number; acquisitionDate: Date; totalAcquisitionCost: number }[],
+    earlierEacLots?: Lot[]
     ): CalculationResult {
         // Filter out non-stock transactions
         const stockTransactions = filterStockTransactions(individualHistory);
@@ -512,7 +531,10 @@ export function calculateTaxResults(
                 date: transaction.date,
                 quantity: Math.abs(transaction.quantity),
             }));
-        const eacLots = buildEACDepositLots(eacHistory);
+        let eacLots = buildEACDepositLots(eacHistory);
+        if (earlierEacLots && earlierEacLots.length > 0) {
+            eacLots = [...earlierEacLots, ...eacLots];
+        }
         const eacForfeitureEvents = buildEACForfeitureEvents(eacHistory);
 
         return {

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -1,4 +1,4 @@
-import { isBefore, isEqual, isAfter, startOfDay } from "date-fns";
+import { isBefore, isEqual, isAfter, startOfDay, max } from "date-fns";
 import _ from "lodash";
 import { ECBConverter } from "../ecbRates";
 import { isWithinAWeek, sortChronologicalBy, sortReverseChronologicalBy } from "../util";
@@ -198,6 +198,8 @@ export type YearEndStatementsByYear = Record<string, YearEndStatementAccounts>;
 export interface CalculationResult {
     taxReport: TaxSaleOfSecurity[],
     yearEndStatementsByYear: YearEndStatementsByYear,
+    /** Latest transaction date in each calendar year across input Individual + EAC histories (uploaded files as passed to calculation). */
+    maxHistoryTransactionDateByYear: Record<string, Date>,
 }
 
 /**
@@ -431,6 +433,30 @@ function buildEACForfeitureEvents(eacHistory: EAC.Transaction[]): ForfeitureEven
     );
 }
 
+function maxHistoryTransactionDateByYearFromInputs(
+    individualHistory: Individual.Transaction[],
+    eacHistory: EAC.Transaction[]
+): Record<string, Date> {
+    const datesByYear = new Map<number, Date[]>();
+    const push = (d: Date) => {
+        const y = d.getFullYear();
+        const list = datesByYear.get(y) ?? [];
+        list.push(d);
+        datesByYear.set(y, list);
+    };
+    for (const t of individualHistory) {
+        push(t.date);
+    }
+    for (const t of eacHistory) {
+        push(t.date);
+    }
+    const result: Record<string, Date> = {};
+    for (const [year, dates] of datesByYear) {
+        result[String(year)] = max(dates);
+    }
+    return result;
+}
+
 function buildYearEndStatementsByYear(
     periods: string[],
     individualLots: Lot[],
@@ -546,5 +572,6 @@ export function calculateTaxResults(
                 eacLots,
                 eacForfeitureEvents
             ),
+            maxHistoryTransactionDateByYear: maxHistoryTransactionDateByYearFromInputs(individualHistory, eacHistory),
         };
     }

--- a/src/calculator/types.ts
+++ b/src/calculator/types.ts
@@ -164,7 +164,6 @@ export namespace EAC {
 
     const OptionsDetails = Record({
         exerciseCostUSD: Number,
-        grossProceedsUSD: Number,
         netProceedsUSD: Number,
     });
 
@@ -210,7 +209,6 @@ export namespace EAC {
         purchaseDate: InstanceOf(Date),
         purchasePriceUSD: Number,
         purchaseFMVUSD: Number,
-        grossProceedsUSD: Number,  
     });
 
     const SaleTransaction = Record({
@@ -292,7 +290,6 @@ export namespace EAC {
         purchaseDate: InstanceOf(Date),
         purchasePriceUSD: Number,
         purchaseFMVUSD: Number,
-        grossProceedsUSD: Number,  
     });
 
     const ForcedQuickSellTransaction = Record({

--- a/src/parser/schwabJSONEACHistoryParser.ts
+++ b/src/parser/schwabJSONEACHistoryParser.ts
@@ -28,7 +28,6 @@ const FIELD_SALE_PURCHASE_FMV = 'PurchaseFairMarketValue';
 // const FIELD_SALE_GRANT_ID = 'GrantId';
 // const FIELD_SALE_VEST_DATE = 'VestDate';
 // const FIELD_SALE_VEST_FMV = 'VestFairMarketValue';
-const FIELD_SALE_GROSS_PROCEEDS = 'GrossProceeds';
 
 const FIELD_LAPSE_AWARD_DATE = 'AwardDate';
 const FIELD_LAPSE_AWARD_ID = 'AwardId';
@@ -48,10 +47,9 @@ const FIELD_EXERCISE_AND_SELL_SALE_PRICE = 'Sale Price';
 const FIELD_EXERCISE_AND_SELL_AWARD_TYPE = 'Award Type';
 const FIELD_EXERCISE_AND_SELL_AWARD_DATE = 'Award Date';
 
-// "","Exercise Cost","Taxes","Gross Proceeds","Net Proceeds",
+// "","Exercise Cost","Taxes",...,"Net Proceeds",
 const FIELD_OPTIONS_DETAILS_EXERCISE_COST = 'Exercise Cost';
 const FIELD_OPTIONS_DETAILS_TAXES = 'Taxes';
-const FIELD_OPTIONS_DETAILS_GROSS_PROCEEDS = 'Gross Proceeds';
 const FIELD_OPTIONS_DETAILS_NET_PROCEEDS = 'Net Proceeds';
 
 // "","Award Id","Action","Shares Exercised","Award Price","Sale Price","Award Type","Award Date",
@@ -120,7 +118,6 @@ export function parseEACHistory(input: string): EAC.Transaction[] {
                     purchaseDate: parseDates(saleDetailsRowLine[FIELD_SALE_PURCHASE_DATE])[0],
                     purchasePriceUSD: parseUSD(saleDetailsRowLine[FIELD_SALE_PURCHASE_PRICE]),
                     purchaseFMVUSD: parseUSD(saleDetailsRowLine[FIELD_SALE_PURCHASE_FMV]),
-                    grossProceedsUSD: parseUSD(saleDetailsRowLine[FIELD_SALE_GROSS_PROCEEDS]),
                 }
                 saleDetailsRows.push(saleDetailsRow);
             }
@@ -155,7 +152,6 @@ export function parseEACHistory(input: string): EAC.Transaction[] {
                     purchaseDate: parseDates(detailsRowLine[FIELD_SALE_PURCHASE_DATE])[0],
                     purchasePriceUSD: parseUSD(detailsRowLine[FIELD_SALE_PURCHASE_PRICE]),
                     purchaseFMVUSD: parseUSD(detailsRowLine[FIELD_SALE_PURCHASE_FMV]),
-                    grossProceedsUSD: parseUSD(detailsRowLine[FIELD_SALE_GROSS_PROCEEDS]),
                 }
                 forcedQuickSellDetailsRows.push(saleDetailsRow);
             }
@@ -192,7 +188,6 @@ export function parseEACHistory(input: string): EAC.Transaction[] {
             const optionsDetailsLine = readLine(parsed.data[i+2], OPTIONS_DETAILS_HEADER);
             const optionsDetails = {
                 exerciseCostUSD: parseUSD(optionsDetailsLine[FIELD_OPTIONS_DETAILS_EXERCISE_COST]),
-                grossProceedsUSD: parseUSD(optionsDetailsLine[FIELD_OPTIONS_DETAILS_GROSS_PROCEEDS]),
                 netProceedsUSD: parseUSD(optionsDetailsLine[FIELD_OPTIONS_DETAILS_NET_PROCEEDS]),
             }
             eacTransaction.details = optionsDetails;
@@ -228,7 +223,6 @@ export function parseEACHistory(input: string): EAC.Transaction[] {
             const optionsDetailsLine = readLine(parsed.data[i+2], OPTIONS_DETAILS_HEADER);
             const optionsDetails = {
                 exerciseCostUSD: parseUSD(optionsDetailsLine[FIELD_OPTIONS_DETAILS_EXERCISE_COST]),
-                grossProceedsUSD: parseUSD(optionsDetailsLine[FIELD_OPTIONS_DETAILS_GROSS_PROCEEDS]),
                 netProceedsUSD: parseUSD(optionsDetailsLine[FIELD_OPTIONS_DETAILS_NET_PROCEEDS]),
             }
             eacTransaction.details = optionsDetails;

--- a/src/parser/yearEndStatementParser.test.ts
+++ b/src/parser/yearEndStatementParser.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { format } from 'date-fns';
+import { parseYearEndStatementExport } from './yearEndStatementParser';
+
+const validJson = JSON.stringify({
+    reportThroughDate: '2023-12-31',
+    generatedAt: "2024-01-01T12:00:00+00:00",
+    appVersion: '0.13.0',
+    accounts: {
+        individual: [
+            { symbol: 'U', quantity: 10, purchaseDate: '2022-06-01', purchasePriceUSD: 40.5 },
+        ],
+        eac: [
+            { symbol: 'U', quantity: 5, purchaseDate: '2023-01-15', purchasePriceUSD: 12.3 },
+        ],
+    },
+});
+
+describe('parseYearEndStatementExport', () => {
+    it('parses a valid year-end export', () => {
+        const r = parseYearEndStatementExport(validJson);
+        expect(format(r.reportThroughDate, 'yyyy-MM-dd')).toBe('2023-12-31');
+        expect(r.individualLots).toHaveLength(1);
+        expect(r.individualLots[0].quantity).toBe(10);
+        expect(r.individualLots[0].purchasePriceUSD).toBe(40.5);
+        expect(r.eacLots).toHaveLength(1);
+        expect(r.eacLots[0].quantity).toBe(5);
+    });
+
+    it('rejects invalid JSON', () => {
+        expect(() => parseYearEndStatementExport('not json')).toThrow(/valid JSON/);
+    });
+
+    it('rejects missing reportThroughDate', () => {
+        expect(() =>
+            parseYearEndStatementExport(JSON.stringify({ accounts: { individual: [], eac: [] } }))
+        ).toThrow(/reportThroughDate/);
+    });
+
+    it('rejects non-U symbol', () => {
+        const bad = JSON.parse(validJson);
+        bad.accounts.individual[0].symbol = 'AAPL';
+        expect(() => parseYearEndStatementExport(JSON.stringify(bad))).toThrow(/symbol/);
+    });
+});

--- a/src/parser/yearEndStatementParser.ts
+++ b/src/parser/yearEndStatementParser.ts
@@ -1,0 +1,105 @@
+import { parseISO, isValid } from 'date-fns';
+
+export type YearEndStatementLot = {
+    symbol: string;
+    quantity: number;
+    purchaseDate: Date;
+    purchasePriceUSD: number;
+};
+
+export type ParsedYearEndStatement = {
+    reportThroughDate: Date;
+    individualLots: YearEndStatementLot[];
+    eacLots: YearEndStatementLot[];
+};
+
+type RawLot = {
+    symbol?: unknown;
+    quantity?: unknown;
+    purchaseDate?: unknown;
+    purchasePriceUSD?: unknown;
+};
+
+function assertU(symbol: string, context: string): void {
+    if (symbol !== 'U') {
+        throw new Error(
+            `Unsupported data in ${context}: symbol "${symbol}". Currently only Unity Technologies Inc. (U) shares are supported.`
+        );
+    }
+}
+
+function parseLot(raw: RawLot, context: string): YearEndStatementLot {
+    if (typeof raw.symbol !== 'string' || raw.symbol === '') {
+        throw new Error(`Invalid ${context} lot: missing symbol`);
+    }
+    assertU(raw.symbol, context);
+
+    const quantity = Number(raw.quantity);
+    if (!Number.isFinite(quantity) || !Number.isInteger(quantity) || quantity <= 0) {
+        throw new Error(`Invalid ${context} lot: quantity must be a positive integer`);
+    }
+
+    if (typeof raw.purchaseDate !== 'string' || raw.purchaseDate === '') {
+        throw new Error(`Invalid ${context} lot: missing purchaseDate`);
+    }
+    const purchaseDate = parseISO(raw.purchaseDate);
+    if (!isValid(purchaseDate)) {
+        throw new Error(`Invalid ${context} lot: could not parse purchaseDate "${raw.purchaseDate}"`);
+    }
+
+    const purchasePriceUSD = Number(raw.purchasePriceUSD);
+    if (!Number.isFinite(purchasePriceUSD) || purchasePriceUSD < 0) {
+        throw new Error(`Invalid ${context} lot: purchasePriceUSD must be a non-negative number`);
+    }
+
+    return {
+        symbol: raw.symbol,
+        quantity,
+        purchaseDate,
+        purchasePriceUSD,
+    };
+}
+
+/**
+ * Parses a year-end statement JSON file produced by this app's "Download Year-End Statement" feature.
+ */
+export function parseYearEndStatementExport(input: string): ParsedYearEndStatement {
+    let data: unknown;
+    try {
+        data = JSON.parse(input);
+    } catch {
+        throw new Error('Year-end statement file is not valid JSON');
+    }
+
+    if (data === null || typeof data !== 'object') {
+        throw new Error('Year-end statement JSON must be an object');
+    }
+
+    const obj = data as Record<string, unknown>;
+    const reportRaw = obj.reportThroughDate;
+    if (typeof reportRaw !== 'string' || reportRaw === '') {
+        throw new Error('Year-end statement is missing reportThroughDate');
+    }
+    const reportThroughDate = parseISO(reportRaw);
+    if (!isValid(reportThroughDate)) {
+        throw new Error(`Could not parse reportThroughDate "${reportRaw}"`);
+    }
+
+    const accounts = obj.accounts;
+    if (accounts === null || typeof accounts !== 'object') {
+        throw new Error('Year-end statement is missing accounts');
+    }
+    const acc = accounts as Record<string, unknown>;
+
+    const indRaw = acc.individual;
+    const eacRaw = acc.eac;
+    if (!Array.isArray(indRaw) || !Array.isArray(eacRaw)) {
+        throw new Error('Year-end statement accounts.individual and accounts.eac must be arrays');
+    }
+
+    return {
+        reportThroughDate,
+        individualLots: indRaw.map((row, i) => parseLot(row as RawLot, `accounts.individual[${i}]`)),
+        eacLots: eacRaw.map((row, i) => parseLot(row as RawLot, `accounts.eac[${i}]`)),
+    };
+}

--- a/src/stories/ResultsPanel.stories.tsx
+++ b/src/stories/ResultsPanel.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { compareAsc } from 'date-fns';
-import { random } from 'lodash';
+import { compareAsc, max } from 'date-fns';
+import { random, uniq } from 'lodash';
 import { TaxSaleOfSecurity } from '../calculator';
 
 import { ResultsPanel } from '../ResultsPanel/ResultsPanel';
@@ -53,17 +53,30 @@ const saleOfSecurity = (data: Partial<TaxSaleOfSecurity> = {}): TaxSaleOfSecurit
   }
 }
 
+const primaryTaxReport = [
+  saleOfSecurity(),
+  saleOfSecurity(),
+  saleOfSecurity(),
+  saleOfSecurity(),
+  saleOfSecurity(),
+  saleOfSecurity(),
+  saleOfSecurity(),
+  saleOfSecurity(),
+].sort((a, b) => compareAsc(a.saleDate, b.saleDate));
+
+const primaryYears = uniq(primaryTaxReport.map((t) => t.saleDate.getFullYear().toString())).sort();
+
 export const Primary = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Primary.args = {
-  taxReport: [
-    saleOfSecurity(),
-    saleOfSecurity(),
-    saleOfSecurity(),
-    saleOfSecurity(),
-    saleOfSecurity(),
-    saleOfSecurity(),
-    saleOfSecurity(),
-    saleOfSecurity(),
-  ].sort((a,b) => compareAsc(a.saleDate, b.saleDate))
+  taxReport: primaryTaxReport,
+  yearEndStatementsByYear: Object.fromEntries(
+    primaryYears.map((y) => [y, { individual: [], eac: [] }])
+  ),
+  maxHistoryTransactionDateByYear: Object.fromEntries(
+    primaryYears.map((y) => {
+      const inYear = primaryTaxReport.filter((t) => t.saleDate.getFullYear().toString() === y);
+      return [y, max(inYear.map((t) => t.saleDate))];
+    })
+  ),
 };

--- a/src/test/data.ts
+++ b/src/test/data.ts
@@ -101,7 +101,6 @@ export namespace EACHistoryData {
             ...overrides,
             details: {
                 exerciseCostUSD: 1250,
-                grossProceedsUSD: 4750,
                 netProceedsUSD: 3499,
             }
         } as EAC.ExerciseAndSellTransaction


### PR DESCRIPTION
## Summary

This branch ships **v0.14.0-beta** ([CHANGELOG.md](CHANGELOG.md), [package.json](package.json)) and focuses on the **end-of-year export / import** workflow: users who already had shares before the Schwab history window can now upload the JSON produced by this app’s “Download Year-End Statement” when modeling a later year. The export side is tightened so **`reportThroughDate` for the latest year** reflects the full uploaded histories (not only the last sale), which keeps import trimming consistent and avoids edge cases around post-sale activity. A small **EAC model cleanup** drops `grossProceedsUSD` from types and Schwab JSON parsing where it was unused or redundant.

## User-visible behavior

- **Optional year-end JSON upload** ([src/InputPanel/AdditionalInput.tsx](src/InputPanel/AdditionalInput.tsx), [src/InputPanel/InputPanel.tsx](src/InputPanel/InputPanel.tsx)): New choice alongside manual “earlier lots”: upload a statement JSON from this calculator. Parsed via [src/parser/yearEndStatementParser.ts](src/parser/yearEndStatementParser.ts) (validated structure, symbol **U** only, integer quantities, ISO dates). Per [CHANGELOG.md](CHANGELOG.md): transactions on or before `reportThroughDate` are omitted from Individual and EAC histories; opening lots from the file apply to both accounts.
- **Year-end export `reportThroughDate`**: For the latest sale year, `reportThroughDate` is aligned with the **latest transaction date in that calendar year** from the histories used in calculation (see commit `618bd3f`), threaded through results UI ([src/ResultsPanel/ResultsPanel.tsx](src/ResultsPanel/ResultsPanel.tsx)) and Storybook ([src/stories/ResultsPanel.stories.tsx](src/stories/ResultsPanel.stories.tsx)).